### PR TITLE
fix: prevent window focus issues with floating window refresh

### DIFF
--- a/lua/chosen.lua
+++ b/lua/chosen.lua
@@ -493,12 +493,8 @@ function H.create_win_config(buf, is_refresh)
         title_pos = ui.title_pos,
     }
 
-    if is_refresh then
-        local win = vim.fn.bufwinid(buf)
-        local pos = vim.api.nvim_win_get_position(win)
-        opts.row = pos[1]
-        opts.col = pos[2]
-    else
+    if not is_refresh then
+        -- for the first time, center window relatively to current window
         opts.col = (vim.api.nvim_win_get_width(0) - opts.width) / 2
         opts.row = (vim.api.nvim_win_get_height(0) - opts.height) / 2
     end
@@ -512,7 +508,20 @@ function H.refresh_win(buf)
    H.render_buf(buf)
     local win = vim.fn.bufwinid(buf)
     if win ~= -1 then
-        vim.api.nvim_win_set_config(win, H.create_win_config(buf, true))
+        local pos = vim.api.nvim_win_get_position(win)
+        local old_config = vim.api.nvim_win_get_config(win)
+        local new_config = H.create_win_config(buf, true)
+
+        -- Calculate difference in sizes
+        local height_diff = new_config.height - old_config.height
+        local width_diff = new_config.width - old_config.width
+
+        -- Adjust position to keep window centered
+        new_config.row = math.max(0, pos[1] - math.ceil(height_diff / 2))
+        new_config.col = math.max(0, pos[2] - math.ceil(width_diff / 2))
+
+
+        vim.api.nvim_win_set_config(win, new_config)
     end
 
     return win
@@ -549,3 +558,4 @@ end
 ---@alias chosen.Win integer
 
 return M
+

--- a/lua/chosen.lua
+++ b/lua/chosen.lua
@@ -48,6 +48,16 @@ function H.set_tbl_default(tbl, val)
     setmetatable(tbl, { __index = function() return val end })
 end
 
+---Utility function to get ceil by absolute value of number
+---@param num number
+---@return number
+function H.abs_ceil(num)
+    if num < 0 then
+        return math.floor(num)
+    end
+    return math.ceil(num)
+end
+
 ---Get icon from webdevicons or mini.icons
 ---@param fname string
 ---@return string?, string?
@@ -505,7 +515,7 @@ end
 ---@param buf chosen.Buf
 ---@return chosen.Win
 function H.refresh_win(buf)
-   H.render_buf(buf)
+    H.render_buf(buf)
     local win = vim.fn.bufwinid(buf)
     if win ~= -1 then
         local pos = vim.api.nvim_win_get_position(win)
@@ -517,9 +527,8 @@ function H.refresh_win(buf)
         local width_diff = new_config.width - old_config.width
 
         -- Adjust position to keep window centered
-        new_config.row = math.max(0, pos[1] - math.ceil(height_diff / 2))
-        new_config.col = math.max(0, pos[2] - math.ceil(width_diff / 2))
-
+        new_config.row = math.max(0, pos[1] - H.abs_ceil(height_diff / 2))
+        new_config.col = math.max(0, pos[2] - H.abs_ceil(width_diff / 2))
 
         vim.api.nvim_win_set_config(win, new_config)
     end
@@ -558,4 +567,3 @@ end
 ---@alias chosen.Win integer
 
 return M
-

--- a/lua/chosen.lua
+++ b/lua/chosen.lua
@@ -515,23 +515,24 @@ end
 ---@param buf chosen.Buf
 ---@return chosen.Win
 function H.refresh_win(buf)
-    H.render_buf(buf)
     local win = vim.fn.bufwinid(buf)
-    if win ~= -1 then
-        local pos = vim.api.nvim_win_get_position(win)
-        local old_config = vim.api.nvim_win_get_config(win)
-        local new_config = H.create_win_config(buf, true)
+    if win == -1 then return win end
 
-        -- Calculate difference in sizes
-        local height_diff = new_config.height - old_config.height
-        local width_diff = new_config.width - old_config.width
+    H.render_buf(buf)
 
-        -- Adjust position to keep window centered
-        new_config.row = math.max(0, pos[1] - H.abs_ceil(height_diff / 2))
-        new_config.col = math.max(0, pos[2] - H.abs_ceil(width_diff / 2))
+    local pos = vim.api.nvim_win_get_position(win)
+    local old_config = vim.api.nvim_win_get_config(win)
+    local new_config = H.create_win_config(buf, true)
 
-        vim.api.nvim_win_set_config(win, new_config)
-    end
+    -- calculate difference in sizes
+    local height_diff = new_config.height - old_config.height
+    local width_diff = new_config.width - old_config.width
+
+    -- adjust position to keep window centered
+    new_config.row = math.max(0, pos[1] - H.abs_ceil(height_diff / 2))
+    new_config.col = math.max(0, pos[2] - H.abs_ceil(width_diff / 2))
+
+    vim.api.nvim_win_set_config(win, new_config)
 
     return win
 end


### PR DESCRIPTION
**Hello, nice plugin!
I experienced some issue, so here is my proposition of a solution**

## Problem
When refreshing the window content (e.g., after deleting or swapping items), the current implementation closes and reopens the window. This can cause focus issues when interacting with other plugins (eg. [lens.vim](https://github.com/camspiers/lens.vim)), as Neovim sometimes fails to properly focus the reopened window.

## Solution
Instead of closing and reopening the window, this PR:
- Introduces a new `refresh_win` function that updates the window content in-place
- Maintains the original window positioning behavior while refreshing
- Updates the window configuration based on whether it's an initial open or a refresh

## Changes
- Added `H.refresh_win` function for in-place window updates
- Modified `H.create_win_config` to handle both initial window creation and refreshes
- Updated mode actions to use refresh instead of reopening the window

## Testing
Manually tested the following scenarios:
- Initial window opening (position relative to current window — like in the original implementation)
- Content updates (delete/swap operations)
- Window focus retention after operations

Probably more scenarios can be tested before merging.